### PR TITLE
Change users/groups table relations

### DIFF
--- a/db/migrations/20210605033719_init.js
+++ b/db/migrations/20210605033719_init.js
@@ -1,17 +1,18 @@
 
 exports.up = function(knex) {
   return knex.schema
+    .createTable('groups', table => {
+      table.increments('id').primary()
+      table.string('group_name')
+      table.timestamps(true, true)
+    })
     .createTable('users', table => {
       table.increments('id').primary()
       table.string('name').notNullable().unique()
       table.string('email').notNullable().unique()
-      table.timestamps(true, true)
-    })
-    .createTable('groups', table => {
-      table.integer('user_id').unsigned().primary()
-      table.foreign('user_id').references('users.id')
       table.integer('daily_score')
-      table.string('group_name')
+      table.integer('group_id').unsigned()
+      table.foreign('group_id').references('groups.id')
       table.timestamps(true, true)
     })
     .createTable('questions', table => {
@@ -30,4 +31,5 @@ exports.down = function(knex) {
   return knex.schema
     .dropTable('users')
     .dropTable('groups')
+    .dropTable('questions')
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,11 +1,11 @@
 const express = require('express')
 const userController = require('../controller/user')
 const groupController = require('../controller/group')
-const questionsController = require('../controller/questions')
+
 
 const router = express.Router()
 router.post('/user', userController.createUser)
 router.post('/group', groupController.createGroup)
-router.post('/questions', questionsController.createQuestions)
+
 
 module.exports = router


### PR DESCRIPTION
#### What does  this PR do?

Updates the database schema to change the relation between users and groups. Specifically, user tables now contain a foreign key of group _id (was reversed previously).

#### Where should the reviewer start?

`/db/migrations`

#### Is this a bug fix or a feature?

Bug Fix

#### How should this be manually tested?

N/A

